### PR TITLE
Update paths for gmslr folder

### DIFF
--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -58,10 +58,12 @@ def calc_future_sea_level(scenario: str) -> None:
                   'glacier', 'landwater']
 
     # Select dimensions from sample file, [time, realisation]
-    sample = np.load(os.path.join(mcdir, f'{scenario}_expansion.npy'))
+    sample = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                                  'data', 'gmslr', 
+                                  f'{scenario}_expansion.npy'))
     nesm = sample.shape[0] # also number of samples to make
     nyrs = sample.shape[1]
-    yrs = np.arange(2007, 2007 + nyrs)
+    yrs = np.arange(2006, 2006 + nyrs)
 
     grid_path = os.path.join(
         settings["cmipinfo"]["sealevelbasedir"], 
@@ -230,7 +232,9 @@ def calculate_sl_components(
         montecarlo_G = da.zeros((nsmps, nyrs, lats, lons), dtype=np.float32) # (no FPs applied)
 
         # Load global projections in for the component
-        mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
+        #mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
+        mc_timeseries = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                                  'data', 'gmslr', f'{scenario}_{comp}.npy'))
         sampled_mc = mc_timeseries[resamples, :nyrs]
         montecarlo_G[:, :] = da.from_array(sampled_mc[:, :, None, None])
 
@@ -460,7 +464,8 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
 
     print('Saving components...')
     gmslr.save_components(
-        os.path.join(settings["emulator_settings"]["gmslr_output_dir"]),
+        os.path.join(settings["baseoutdir"],settings["experiment_name"],
+            'data', 'gmslr'),
         scenario)
     print('Saved!\n')
 
@@ -480,6 +485,14 @@ def main():
             settings["baseoutdir"], 
             settings["experiment_name"])
     ).mkdir(parents=True, exist_ok=True)
+
+    Path(
+        os.path.join(
+            settings["baseoutdir"],
+            settings["experiment_name"],
+            'data', 'gmslr')
+    ).mkdir(parents=True, exist_ok=True)
+
     Path(
         read_dir()[4]
     ).mkdir(parents=True, exist_ok=True)

--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -59,8 +59,8 @@ def calc_future_sea_level(scenario: str) -> None:
 
     # Select dimensions from sample file, [time, realisation]
     sample = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                                  'data', 'gmslr', 
-                                  f'{scenario}_expansion.npy'))
+                                  'data', 'gmslr', f'{scenario}_expansion.npy'))
+    
     nesm = sample.shape[0] # also number of samples to make
     nyrs = sample.shape[1]
     yrs = np.arange(2006, 2006 + nyrs)
@@ -234,7 +234,8 @@ def calculate_sl_components(
         # Load global projections in for the component
         #mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
         mc_timeseries = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                                  'data', 'gmslr', f'{scenario}_{comp}.npy'))
+                                             'data','gmslr',f'{scenario}_{comp}.npy'))
+        print("data read: ", mc_timeseries)
         sampled_mc = mc_timeseries[resamples, :nyrs]
         montecarlo_G[:, :] = da.from_array(sampled_mc[:, :, None, None])
 
@@ -465,9 +466,11 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
     print('Saving components...')
     gmslr.save_components(
         os.path.join(settings["baseoutdir"],settings["experiment_name"],
-            'data', 'gmslr'),
+                     'data', 'gmslr'),
         scenario)
-    print('Saved!\n')
+    print('Saved at: ',
+          os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                       'data', 'gmslr'),'\n')
 
 
 def main():

--- a/profsea/user-settings-emu.yml
+++ b/profsea/user-settings-emu.yml
@@ -10,14 +10,14 @@
 #   N.B. if other site name: latlon needs to be specified
         # sitelatlon: [[-51.69, -57.82]])
 siteinfo:
-    region: 'cmip7_example'   # str
+    region: 'cmip6_patterns'   # str
     sitename: ['Stanley II']     # list
     sitelatlon: [[]]             # list
 
 # Base output directory
 #   N.B. the code will add region to the output directory
-experiment_name: 'cmip7_example'
-baseoutdir: '/add/your/directory/'
+experiment_name: 'fair_example'
+baseoutdir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/'
 
 # Set the end year of the projection(s)
 projection_end_year: 2300 # int between 2050 and 2300
@@ -26,13 +26,13 @@ projection_end_year: 2300 # int between 2050 and 2300
 emulator_settings:
     emulator_mode: true # bool
     use_input_ensemble: true # bool
-    gmslr_output_dir: '/ProFSea/ProFSea-tool/data/runs/gmslr'
-    emulator_scenario: ['high-extension', 'high-overshoot', 'medium-extension', 'medium-overshoot', 'low', 'verylow', 'verylow-overshoot'] # str
+    gmslr_output_dir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/gmslr'
+    emulator_scenario: ['high-overshoot', 'medium-overshoot', 'low', 'verylow-overshoot'] # str
     
 scm_data:
-    temperature: '/results/fair_output/cmip7_temperature.nc' # str
-    ocean_heat_content: '/results/fair_output/cmip7_ohc.nc' # str
-    cumulative_emissions: '/data/cumulative_cmip7_emissions.json' # str
+    temperature: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_temperature.nc' # str
+    ocean_heat_content: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_ohc.nc' # str
+    cumulative_emissions: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cumulative_scenario_emissions.json' # str
 
 # Science method
 #   UKCP18 --> sciencemethod: 'UK'
@@ -49,7 +49,7 @@ sciencemethod: 'global'  # str
 tidegaugeinfo:
     source: 'PSMSL'    # str
     datafq: ['annual'] # list
-    psmsldir: '/home/user/data/PSMSL/'
+    psmsldir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/PSMSL/'
 
 # CMIP information
 cmipinfo:
@@ -59,25 +59,25 @@ cmipinfo:
 #   Marginal sea --> cmip_sea: 'marginal'
     cmip_sea: 'all'     # str
 # sealevelbasedir: Base directory for CMIP "zos" and "zostoga" data
-    sealevelbasedir: '/data/cmip6/'
+    sealevelbasedir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/cmip6/'
 # slopecoeffsuk: CMIP5 slope coefficients developed for UKCP18
-    slopecoeffsuk: '/data/uk_cmip_slope_coefficients/'
+    slopecoeffsuk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/uk_cmip_slope_coefficients/'
 
 
 # Directories for the GIA estimates (independent of scenario)
 #   UKCP18 --> UK specific ones
 #   Global locations --> Lambeck, ICE5G
 giaestimates:
-    global: '/data/gia_estimates/global_GIA_interpolators.pickle'
-    uk: '‘/data/gia_estimates/Bradley_GIA_interpolator.pickle'
+    global: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/global_GIA_interpolators.pickle'
+    uk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/Bradley_GIA_interpolator.pickle'
 
 # Directories for the Slangen, Spada and Klemann fingerprints
 fingerprints:
-    slangendir: '/data/grd_fingerprints/'
-    spadadir: '/data/grd_fingerprints/'
-    klemanndir: '/data/grd_fingerprints/'
+    slangendir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
+    spadadir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
+    klemanndir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
 
 # Directory of Monte Carlo time series for new projections
 #   N.B. Originally developed by Jonathan Gregory
-short_montecarlodir: '/path/to/2100/montecarlo/simulations' # Required for projections up to 2100
-long_montecarlodir: '/data/runs/emulator_output' # Required for projections from 2100 up to 2300
+short_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/monte_carlo_timeseries/' # Required for projections up to 2100
+long_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/emulator_output' # Required for projections from 2100 up to 2300

--- a/profsea/user-settings-emu.yml
+++ b/profsea/user-settings-emu.yml
@@ -10,14 +10,14 @@
 #   N.B. if other site name: latlon needs to be specified
         # sitelatlon: [[-51.69, -57.82]])
 siteinfo:
-    region: 'cmip6_patterns'   # str
+    region: 'cmip7_example'   # str
     sitename: ['Stanley II']     # list
     sitelatlon: [[]]             # list
 
 # Base output directory
 #   N.B. the code will add region to the output directory
-experiment_name: 'fair_example'
-baseoutdir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/'
+experiment_name: 'cmip7_example'
+baseoutdir: '/add/your/directory/'
 
 # Set the end year of the projection(s)
 projection_end_year: 2300 # int between 2050 and 2300
@@ -26,13 +26,13 @@ projection_end_year: 2300 # int between 2050 and 2300
 emulator_settings:
     emulator_mode: true # bool
     use_input_ensemble: true # bool
-    gmslr_output_dir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/gmslr'
-    emulator_scenario: ['high-overshoot', 'medium-overshoot', 'low', 'verylow-overshoot'] # str
+    gmslr_output_dir: '/ProFSea/ProFSea-tool/data/runs/gmslr'
+    emulator_scenario: ['high-extension', 'high-overshoot', 'medium-extension', 'medium-overshoot', 'low', 'verylow', 'verylow-overshoot'] # str
     
 scm_data:
-    temperature: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_temperature.nc' # str
-    ocean_heat_content: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_ohc.nc' # str
-    cumulative_emissions: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cumulative_scenario_emissions.json' # str
+    temperature: '/results/fair_output/cmip7_temperature.nc' # str
+    ocean_heat_content: '/results/fair_output/cmip7_ohc.nc' # str
+    cumulative_emissions: '/data/cumulative_cmip7_emissions.json' # str
 
 # Science method
 #   UKCP18 --> sciencemethod: 'UK'
@@ -49,7 +49,7 @@ sciencemethod: 'global'  # str
 tidegaugeinfo:
     source: 'PSMSL'    # str
     datafq: ['annual'] # list
-    psmsldir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/PSMSL/'
+    psmsldir: '/home/user/data/PSMSL/'
 
 # CMIP information
 cmipinfo:
@@ -59,25 +59,25 @@ cmipinfo:
 #   Marginal sea --> cmip_sea: 'marginal'
     cmip_sea: 'all'     # str
 # sealevelbasedir: Base directory for CMIP "zos" and "zostoga" data
-    sealevelbasedir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/cmip6/'
+    sealevelbasedir: '/data/cmip6/'
 # slopecoeffsuk: CMIP5 slope coefficients developed for UKCP18
-    slopecoeffsuk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/uk_cmip_slope_coefficients/'
+    slopecoeffsuk: '/data/uk_cmip_slope_coefficients/'
 
 
 # Directories for the GIA estimates (independent of scenario)
 #   UKCP18 --> UK specific ones
 #   Global locations --> Lambeck, ICE5G
 giaestimates:
-    global: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/global_GIA_interpolators.pickle'
-    uk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/Bradley_GIA_interpolator.pickle'
+    global: '/data/gia_estimates/global_GIA_interpolators.pickle'
+    uk: '‘/data/gia_estimates/Bradley_GIA_interpolator.pickle'
 
 # Directories for the Slangen, Spada and Klemann fingerprints
 fingerprints:
-    slangendir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
-    spadadir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
-    klemanndir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
+    slangendir: '/data/grd_fingerprints/'
+    spadadir: '/data/grd_fingerprints/'
+    klemanndir: '/data/grd_fingerprints/'
 
 # Directory of Monte Carlo time series for new projections
 #   N.B. Originally developed by Jonathan Gregory
-short_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/monte_carlo_timeseries/' # Required for projections up to 2100
-long_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/emulator_output' # Required for projections from 2100 up to 2300
+short_montecarlodir: '/path/to/2100/montecarlo/simulations' # Required for projections up to 2100
+long_montecarlodir: '/data/runs/emulator_output' # Required for projections from 2100 up to 2300


### PR DESCRIPTION
This pull request is for adding code for creating `gmslr` folder, which is now created  inside the `experiment_name` directory. 

``os.path.join(settings["baseoutdir"],settings["experiment_name"], 'data', 'gmslr')``

With these changes, `gmslr_output_dir` input is not required in `user-settings-emu.yml`. However, `user-settings-emu.yml` is unchanged in this pull request.

Additionally,  the range for `yrs` has been changed to (2006, 2006+nyrs) for consistency with Palmer et al. (2020). 