### PR TITLE
User-defined path for user-settings.yml

### DIFF
--- a/profsea/config.py
+++ b/profsea/config.py
@@ -6,8 +6,25 @@ All rights reserved.
 import os
 import pathlib
 import yaml
+import argparse
 
-path = pathlib.Path(__file__).parents[0].as_posix()
+
+# Create argument parser
+parser = argparse.ArgumentParser(description="Run script with optional custom path")
+parser.add_argument("--path", type=str, help="Supply the directory path (optional)")
+
+# Parse arguments
+args = parser.parse_args()
+
+
+# Use user-supplied path if given, else fallback to script's directory
+if args.path:
+    path = pathlib.Path(args.path).as_posix()
+else:
+    path = pathlib.Path(__file__).parents[0].as_posix()
+
 
 with open(os.path.join(path, "user-settings-emu.yml"), "r") as f:
     settings = yaml.load(f, Loader=yaml.SafeLoader)
+
+print(f"Using path: {path}")

--- a/profsea/emulator/__init__.py
+++ b/profsea/emulator/__init__.py
@@ -254,6 +254,17 @@ class GMSLREmulator:
                 component
             )
 
+        # Save data in netcdf format (store all components in an xarray dataset)
+        # Assumes first dimension is percentile, but can be more general (percentile/ensemble)
+        ds = xr.Dataset()
+        for name, component in self.get_components().items():
+            xr_dataArray = xr.DataArray(component, dims=["percentile", "time"], 
+                                        coords={"percentile": np.arange(0,101), 
+                                                "time": np.arange(2006, component.shape[1] + 2006)})
+            xr_dataArray.attrs["units"] = "meter"
+            ds[name] = xr_dataArray
+        ds.to_netcdf(os.path.join(output_dir,f'{scenario_name}.nc'))
+
     def project(self) -> None:
         """Run the emulator to project GMSLR components.
 
@@ -296,6 +307,8 @@ class GMSLREmulator:
             self.glacier = self.sample_members_2D(self.glacier)
             self.greenland_ar6 = self.sample_members_2D(self.greenland_ar6)
             self.landwater = self.sample_members_2D(self.landwater)
+            self.greensmb = self.sample_members_2D(self.greensmb)
+            self.greendyn = self.sample_members_2D(self.greendyn)
             # self.greenland_ar5 = self.sample_members_2D(self.greenland_ar5)
             # self.landwater_ar6 = self.sample_members_2D(self.landwater_ar6)
 

--- a/profsea/emulator/__init__.py
+++ b/profsea/emulator/__init__.py
@@ -259,11 +259,11 @@ class GMSLREmulator:
         ds = xr.Dataset()
         for name, component in self.get_components().items():
             xr_dataArray = xr.DataArray(component, dims=["percentile", "time"], 
-                                        coords={"percentile": np.arange(0,101), 
+                                        coords={"percentile": self.output_percentiles, 
                                                 "time": np.arange(2006, component.shape[1] + 2006)})
-            xr_dataArray.attrs["units"] = "meter"
+            xr_dataArray.attrs["units"] = "m"
             ds[name] = xr_dataArray
-        ds.to_netcdf(os.path.join(output_dir,f'{scenario_name}.nc'))
+        ds.to_netcdf(os.path.join(output_dir,f'{scenario_name}_global.nc'))
 
     def project(self) -> None:
         """Run the emulator to project GMSLR components.

--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -477,6 +477,7 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
         raise Exception('SCM data must be saved in NetCDF format.')
 
     percentiles = np.arange(101)
+    # percentiles are hard coded. We could make it an user input in future updates.
 
     # Now run the simulations
     console.log(f'Projecting global components for {scenario} scenario...')
@@ -498,7 +499,7 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
         settings["projection_end_year"],
         palmer_method=palmer_method,
         input_ensemble=settings["emulator_settings"]["use_input_ensemble"],
-        output_percentiles=np.arange(101),
+        output_percentiles=percentiles,
         cum_emissions_total=cumulative_emissions[scenario])
     gmslr.project()
 

--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -58,10 +58,12 @@ def calc_future_sea_level(scenario: str) -> None:
                   'glacier', 'landwater']
 
     # Select dimensions from sample file, [time, realisation]
-    sample = np.load(os.path.join(mcdir, f'{scenario}_expansion.npy'))
+    sample = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                                  'data', 'gmslr', 
+                                  f'{scenario}_expansion.npy'))
     nesm = sample.shape[0] # also number of samples to make
     nyrs = sample.shape[1]
-    yrs = np.arange(2007, 2007 + nyrs)
+    yrs = np.arange(2006, 2006 + nyrs)
 
     grid_path = os.path.join(
         settings["cmipinfo"]["sealevelbasedir"], 
@@ -230,7 +232,9 @@ def calculate_sl_components(
         montecarlo_G = da.zeros((nsmps, nyrs, lats, lons), dtype=np.float32) # (no FPs applied)
 
         # Load global projections in for the component
-        mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
+        #mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
+        mc_timeseries = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                                  'data', 'gmslr', f'{scenario}_{comp}.npy'))
         sampled_mc = mc_timeseries[resamples, :nyrs]
         montecarlo_G[:, :] = da.from_array(sampled_mc[:, :, None, None])
 
@@ -460,7 +464,8 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
 
     print('Saving components...')
     gmslr.save_components(
-        os.path.join(settings["emulator_settings"]["gmslr_output_dir"]),
+        os.path.join(settings["baseoutdir"],settings["experiment_name"],
+            'data', 'gmslr'),
         scenario)
     print('Saved!\n')
 
@@ -480,6 +485,14 @@ def main():
             settings["baseoutdir"], 
             settings["experiment_name"])
     ).mkdir(parents=True, exist_ok=True)
+
+    Path(
+        os.path.join(
+            settings["baseoutdir"],
+            settings["experiment_name"],
+            'data', 'gmslr')
+    ).mkdir(parents=True, exist_ok=True)
+
     Path(
         read_dir()[4]
     ).mkdir(parents=True, exist_ok=True)

--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -59,8 +59,8 @@ def calc_future_sea_level(scenario: str) -> None:
 
     # Select dimensions from sample file, [time, realisation]
     sample = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                                  'data', 'gmslr', 
-                                  f'{scenario}_expansion.npy'))
+                                  'data', 'gmslr', f'{scenario}_expansion.npy'))
+    
     nesm = sample.shape[0] # also number of samples to make
     nyrs = sample.shape[1]
     yrs = np.arange(2006, 2006 + nyrs)
@@ -234,7 +234,8 @@ def calculate_sl_components(
         # Load global projections in for the component
         #mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
         mc_timeseries = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                                  'data', 'gmslr', f'{scenario}_{comp}.npy'))
+                                             'data','gmslr',f'{scenario}_{comp}.npy'))
+        print("data read: ", mc_timeseries)
         sampled_mc = mc_timeseries[resamples, :nyrs]
         montecarlo_G[:, :] = da.from_array(sampled_mc[:, :, None, None])
 
@@ -465,9 +466,11 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
     print('Saving components...')
     gmslr.save_components(
         os.path.join(settings["baseoutdir"],settings["experiment_name"],
-            'data', 'gmslr'),
+                     'data', 'gmslr'),
         scenario)
-    print('Saved!\n')
+    print('Saved at: ',
+          os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                       'data', 'gmslr'),'\n')
 
 
 def main():

--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -67,12 +67,9 @@ def calc_future_sea_level(scenario: str) -> None:
     
     nesm = sample.shape[0] # also number of samples to make
     nyrs = sample.shape[1]
-<<<<<<< HEAD
+    
     yrs = np.arange(2006, 2006 + nyrs)
-=======
-    yrs = np.arange(2007, 2007 + nyrs)
     console.log(f"Running with {nesm} ensemble members")
->>>>>>> emu-update-greg
 
     grid_path = os.path.join(
         settings["cmipinfo"]["sealevelbasedir"], 

--- a/profsea/user-settings-emu.yml
+++ b/profsea/user-settings-emu.yml
@@ -10,14 +10,14 @@
 #   N.B. if other site name: latlon needs to be specified
         # sitelatlon: [[-51.69, -57.82]])
 siteinfo:
-    region: 'cmip7_example'   # str
+    region: 'cmip6_patterns'   # str
     sitename: ['Stanley II']     # list
     sitelatlon: [[]]             # list
 
 # Base output directory
 #   N.B. the code will add region to the output directory
-experiment_name: 'cmip7_example'
-baseoutdir: '/add/your/directory/'
+experiment_name: 'fair_example'
+baseoutdir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/'
 
 # Set the end year of the projection(s)
 projection_end_year: 2300 # int between 2050 and 2300
@@ -26,13 +26,13 @@ projection_end_year: 2300 # int between 2050 and 2300
 emulator_settings:
     emulator_mode: true # bool
     use_input_ensemble: true # bool
-    gmslr_output_dir: '/ProFSea/ProFSea-tool/data/runs/gmslr'
-    emulator_scenario: ['high-extension', 'high-overshoot', 'medium-extension', 'medium-overshoot', 'low', 'verylow', 'verylow-overshoot'] # str
+    gmslr_output_dir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/gmslr'
+    emulator_scenario: ['high-overshoot', 'medium-overshoot', 'low', 'verylow-overshoot'] # str
     
 scm_data:
-    temperature: '/results/fair_output/cmip7_temperature.nc' # str
-    ocean_heat_content: '/results/fair_output/cmip7_ohc.nc' # str
-    cumulative_emissions: '/data/cumulative_cmip7_emissions.json' # str
+    temperature: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_temperature.nc' # str
+    ocean_heat_content: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_ohc.nc' # str
+    cumulative_emissions: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cumulative_scenario_emissions.json' # str
 
 # Science method
 #   UKCP18 --> sciencemethod: 'UK'
@@ -49,7 +49,7 @@ sciencemethod: 'global'  # str
 tidegaugeinfo:
     source: 'PSMSL'    # str
     datafq: ['annual'] # list
-    psmsldir: '/home/user/data/PSMSL/'
+    psmsldir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/PSMSL/'
 
 # CMIP information
 cmipinfo:
@@ -59,25 +59,25 @@ cmipinfo:
 #   Marginal sea --> cmip_sea: 'marginal'
     cmip_sea: 'all'     # str
 # sealevelbasedir: Base directory for CMIP "zos" and "zostoga" data
-    sealevelbasedir: '/data/cmip6/'
+    sealevelbasedir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/cmip6/'
 # slopecoeffsuk: CMIP5 slope coefficients developed for UKCP18
-    slopecoeffsuk: '/data/uk_cmip_slope_coefficients/'
+    slopecoeffsuk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/uk_cmip_slope_coefficients/'
 
 
 # Directories for the GIA estimates (independent of scenario)
 #   UKCP18 --> UK specific ones
 #   Global locations --> Lambeck, ICE5G
 giaestimates:
-    global: '/data/gia_estimates/global_GIA_interpolators.pickle'
-    uk: '‘/data/gia_estimates/Bradley_GIA_interpolator.pickle'
+    global: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/global_GIA_interpolators.pickle'
+    uk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/Bradley_GIA_interpolator.pickle'
 
 # Directories for the Slangen, Spada and Klemann fingerprints
 fingerprints:
-    slangendir: '/data/grd_fingerprints/'
-    spadadir: '/data/grd_fingerprints/'
-    klemanndir: '/data/grd_fingerprints/'
+    slangendir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
+    spadadir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
+    klemanndir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
 
 # Directory of Monte Carlo time series for new projections
 #   N.B. Originally developed by Jonathan Gregory
-short_montecarlodir: '/path/to/2100/montecarlo/simulations' # Required for projections up to 2100
-long_montecarlodir: '/data/runs/emulator_output' # Required for projections from 2100 up to 2300
+short_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/monte_carlo_timeseries/' # Required for projections up to 2100
+long_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/emulator_output' # Required for projections from 2100 up to 2300

--- a/profsea/user-settings-emu.yml
+++ b/profsea/user-settings-emu.yml
@@ -10,14 +10,14 @@
 #   N.B. if other site name: latlon needs to be specified
         # sitelatlon: [[-51.69, -57.82]])
 siteinfo:
-    region: 'cmip6_patterns'   # str
+    region: 'cmip7_example'   # str
     sitename: ['Stanley II']     # list
     sitelatlon: [[]]             # list
 
 # Base output directory
 #   N.B. the code will add region to the output directory
-experiment_name: 'fair_example'
-baseoutdir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/'
+experiment_name: 'cmip7_example'
+baseoutdir: '/add/your/directory/'
 
 # Set the end year of the projection(s)
 projection_end_year: 2300 # int between 2050 and 2300
@@ -26,13 +26,13 @@ projection_end_year: 2300 # int between 2050 and 2300
 emulator_settings:
     emulator_mode: true # bool
     use_input_ensemble: true # bool
-    gmslr_output_dir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/gmslr'
-    emulator_scenario: ['high-overshoot', 'medium-overshoot', 'low', 'verylow-overshoot'] # str
+    gmslr_output_dir: '/ProFSea/ProFSea-tool/data/runs/gmslr'
+    emulator_scenario: ['high-extension', 'high-overshoot', 'medium-extension', 'medium-overshoot', 'low', 'verylow', 'verylow-overshoot'] # str
     
 scm_data:
-    temperature: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_temperature.nc' # str
-    ocean_heat_content: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cmip6_ohc.nc' # str
-    cumulative_emissions: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/FAIR-output/cumulative_scenario_emissions.json' # str
+    temperature: '/results/fair_output/cmip7_temperature.nc' # str
+    ocean_heat_content: '/results/fair_output/cmip7_ohc.nc' # str
+    cumulative_emissions: '/data/cumulative_cmip7_emissions.json' # str
 
 # Science method
 #   UKCP18 --> sciencemethod: 'UK'
@@ -49,7 +49,7 @@ sciencemethod: 'global'  # str
 tidegaugeinfo:
     source: 'PSMSL'    # str
     datafq: ['annual'] # list
-    psmsldir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/PSMSL/'
+    psmsldir: '/home/user/data/PSMSL/'
 
 # CMIP information
 cmipinfo:
@@ -59,25 +59,25 @@ cmipinfo:
 #   Marginal sea --> cmip_sea: 'marginal'
     cmip_sea: 'all'     # str
 # sealevelbasedir: Base directory for CMIP "zos" and "zostoga" data
-    sealevelbasedir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/cmip6/'
+    sealevelbasedir: '/data/cmip6/'
 # slopecoeffsuk: CMIP5 slope coefficients developed for UKCP18
-    slopecoeffsuk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/uk_cmip_slope_coefficients/'
+    slopecoeffsuk: '/data/uk_cmip_slope_coefficients/'
 
 
 # Directories for the GIA estimates (independent of scenario)
 #   UKCP18 --> UK specific ones
 #   Global locations --> Lambeck, ICE5G
 giaestimates:
-    global: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/global_GIA_interpolators.pickle'
-    uk: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/gia_estimates/Bradley_GIA_interpolator.pickle'
+    global: '/data/gia_estimates/global_GIA_interpolators.pickle'
+    uk: '‘/data/gia_estimates/Bradley_GIA_interpolator.pickle'
 
 # Directories for the Slangen, Spada and Klemann fingerprints
 fingerprints:
-    slangendir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
-    spadadir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
-    klemanndir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/grd_fingerprints/'
+    slangendir: '/data/grd_fingerprints/'
+    spadadir: '/data/grd_fingerprints/'
+    klemanndir: '/data/grd_fingerprints/'
 
 # Directory of Monte Carlo time series for new projections
 #   N.B. Originally developed by Jonathan Gregory
-short_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/data-profsea/monte_carlo_timeseries/' # Required for projections up to 2100
-long_montecarlodir: '/data/users/hemant.khatri/ProFSea-Runs/test-runs/FAIR-calibrated-ensemble/emulator_output' # Required for projections from 2100 up to 2300
+short_montecarlodir: '/path/to/2100/montecarlo/simulations' # Required for projections up to 2100
+long_montecarlodir: '/data/runs/emulator_output' # Required for projections from 2100 up to 2300


### PR DESCRIPTION
This pull request adds mainly two changes.

1. **Option to supply path for user-settings-emu.yml file by the user** - Code runs into error if `spatial-projections.py` and `user-settings-emu.yml` files are not in the profsea git directory. The suggested change allows user to run ProFSea from any directory using the following syntax. If no path is supplied, then it falls back to the original code.
      ``python spatial_projections.py --path user-path``

2.  **Save global component is netcdf file**  - In addition to .npy formats, the code aupdate saves all global components in a single netcdf file. Metadata and information about different components is not yet there and the code can be updated to add metadata. 

The third minor change is - `greensmb` and `greendyn` components are now converted into percentiles before saving the data. 
