### PR TITLE
Streamline file paths and remove hard-coded directory paths

### DIFF
--- a/profsea/spatial_projections.py
+++ b/profsea/spatial_projections.py
@@ -63,7 +63,7 @@ def calc_future_sea_level(scenario: str) -> None:
 
     # Select dimensions from sample file, [time, realisation]
     sample = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                                  'data', 'gmslr', f'{scenario}_expansion.npy'))
+                                  settings['emulator_settings']['gmslr_output_dir'], f'{scenario}_expansion.npy'))
     
     nesm = sample.shape[0] # also number of samples to make
     nyrs = sample.shape[1]
@@ -112,7 +112,8 @@ def calc_gia_contribution(
 
     file_header = '_'.join(['gia', scenario, "projection", 
                     f"{settings['projection_end_year']}"])
-    sealev_ddir = read_dir()[4]
+    sealev_ddir = os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                               settings['emulator_settings']['spatial_output_dir'])
 
     # Save data in netcdf format (Assuming first dimension is percentile, but can be more general percentile/ensemble)
     xr_dataArray = xr.DataArray(GIA_series, dims=["percentile", "time", "lat", "lon"], 
@@ -233,7 +234,8 @@ def save_projections(
     :param scenario: emission scenario
     :param percentile: percentiles used for spatial projections
     """
-    sealev_ddir = read_dir()[4]
+    sealev_ddir = os.path.join(settings["baseoutdir"],settings["experiment_name"],
+                               settings['emulator_settings']['spatial_output_dir'])
     file_header = '_'.join([component, scenario, "projection", 
                             f"{settings['projection_end_year']}"])
 
@@ -286,7 +288,7 @@ def calculate_sl_components(
         # Load global projections in for the component
         #mc_timeseries = np.load(os.path.join(mcdir, f'{scenario}_{comp}.npy'))
         mc_timeseries = np.load(os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                                             'data','gmslr',f'{scenario}_{comp}.npy'))
+                                             settings['emulator_settings']['gmslr_output_dir'],f'{scenario}_{comp}.npy'))
         sampled_mc = mc_timeseries[resamples, :nyrs]
         montecarlo_G[:, :] = da.from_array(sampled_mc[:, :, None, None])
 
@@ -530,7 +532,7 @@ def calculate_global_components(scenario: str, palmer_method: bool) -> None:
     console.log('Saving components...')
     gmslr.save_components(
         os.path.join(settings["baseoutdir"],settings["experiment_name"],
-                     'data', 'gmslr'),
+                     settings['emulator_settings']['gmslr_output_dir']),
         scenario)
 
 
@@ -558,11 +560,14 @@ def main():
         os.path.join(
             settings["baseoutdir"],
             settings["experiment_name"],
-            'data', 'gmslr')
+            settings['emulator_settings']['gmslr_output_dir'])
     ).mkdir(parents=True, exist_ok=True)
 
     Path(
-        read_dir()[4]
+        os.path.join(
+            settings["baseoutdir"],
+            settings["experiment_name"],
+            settings['emulator_settings']['spatial_output_dir'])
     ).mkdir(parents=True, exist_ok=True)
 
     # Extract site data from station list (e.g. tide gauge location) or

--- a/profsea/user-settings-emu.yml
+++ b/profsea/user-settings-emu.yml
@@ -16,8 +16,8 @@ siteinfo:
 
 # Base output directory
 #   N.B. the code will add region to the output directory
-experiment_name: 'cmip7_example'
-baseoutdir: '/add/your/directory/'
+experiment_name: 'exp_name' # str
+baseoutdir: '/add/your/directory/' # all output will be saved inside baseoutdir/exp_name/
 
 # Set the end year of the projection(s)
 projection_end_year: 2300 # int between 2050 and 2300
@@ -26,13 +26,14 @@ projection_end_year: 2300 # int between 2050 and 2300
 emulator_settings:
     emulator_mode: true # bool
     use_input_ensemble: true # bool
-    gmslr_output_dir: '/ProFSea/ProFSea-tool/data/runs/gmslr'
+    gmslr_output_dir: 'gmslr' # str # directory name to save global projections
+    spatial_output_dir: 'sea_level_projections' # str # directory name to save spatial projections
     emulator_scenario: ['high-extension', 'high-overshoot', 'medium-extension', 'medium-overshoot', 'low', 'verylow', 'verylow-overshoot'] # str
     
 scm_data:
-    temperature: '/results/fair_output/cmip7_temperature.nc' # str
-    ocean_heat_content: '/results/fair_output/cmip7_ohc.nc' # str
-    cumulative_emissions: '/data/cumulative_cmip7_emissions.json' # str
+    temperature: '/path/to/temperature.nc' # str # global-mean surface temperature file
+    ocean_heat_content: '/path/to/ohc.nc' # str # ocean heat content file 
+    cumulative_emissions: '/path/to/emissions.json' # str # cumulative emissions file
 
 # Science method
 #   UKCP18 --> sciencemethod: 'UK'


### PR DESCRIPTION
The pull requests addressees issue #26. Hard-coded filepaths are now removed and locations for saving outputs is provided in `user-settings-emu.yml` via inputs `gmslr_output_dir` and `spatial_output_dir`.

Additionally, the `read_dir` function is not used in the updated code, so all directory paths are now controlled via `user-settings-emu.yml` 

@gregrmunday Could you please review it?