### PR TITLE
Fix plotting errors near dateline

### DIFF
--- a/profsea/slr_pkg/__init__.py
+++ b/profsea/slr_pkg/__init__.py
@@ -244,6 +244,16 @@ def plot_ij(cube, model, location, idx, lat, lon, save_map=True, rad=5):
     if targetlon > 180:
         targetlon -= 360
 
+    # ensure between max and min lon
+    if plotlon > maxlon:
+        plotlon -= 360
+    if plotlon < minlon:
+        plotlon += 360
+    if targetlon > maxlon:
+        targetlon -= 360
+    if targetlon < minlon:
+        targetlon += 360
+
     fig = plt.figure()
     ax = cubeplot.block(cube, land=False, region=region, cmin=-1, cmax=1,
                         plotcbar=True, nlevels=25, cent_lon=targetlon,


### PR DESCRIPTION
Target locations between ~172 and 180 longitude were causing a crash. This looked to happen when the region to plot crossed the dateline, with the site on the West (i.e. NZ/Russia) side. The region was shifted, but not the location creating a discrepancy. This PR modifies __init__.py to shift the target/plot site to be within the region to plot.