### PR TITLE
Profsea v3 adding documentation to profsea software

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,68 @@
+# (C) Crown Copyright 2025, Met Office.
+# The LICENSE file contains full licensing details.
+name: Build and deploy the documentation
+
+on:
+  # Runs on pushes targeting the default branch.
+  push:
+    branches: ["profsea-climate-v2"]
+
+  # Allows you to run this workflow manually from the Actions tab.
+  workflow_dispatch:
+
+# Use a login shell so the Conda environment is activated.
+defaults:
+  run:
+    shell: bash -leo pipefail {0}
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment,
+# skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs
+# as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-file: docs-environment.yml
+          environment-name: profsea-climate-docs
+          cache-environment: true
+          cache-environment-key: env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('docs-environment.yml') }}
+
+      - name: Build with Sphinx
+        run:  make --directory=docs html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/build/html
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ name: Build and deploy the documentation
 on:
   # Runs on pushes targeting the default branch.
   push:
-    branches: ["profsea-climate-v2"]
+    branches: ["profsea-v3"]
 
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *__pycache__*
 profsea.egg-info
 data/
+# Ignore the documentation build directory
+docs/build
 *.DS_Store
 .ipynb_checkpoints/

--- a/docs-environment.yml
+++ b/docs-environment.yml
@@ -1,4 +1,4 @@
-name: profsea-climate-docs
+name: profsea-sphinx-docs
 
 
 
@@ -6,3 +6,5 @@ dependencies:
   - pre-commit
   - pydata-sphinx-theme
   - sphinx
+  - nbsphinx
+  - pandoc

--- a/docs-environment.yml
+++ b/docs-environment.yml
@@ -1,0 +1,8 @@
+name: profsea-climate-docs
+
+
+
+dependencies:
+  - pre-commit
+  - pydata-sphinx-theme
+  - sphinx

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -1,0 +1,53 @@
+API Reference
+=============
+
+This page exposes selected Python API docs generated from in-code docstrings.
+
+Core Models
+-----------
+
+.. automodule:: profsea.components.core.global_model
+   :members: Global
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: profsea.components.core.spatial_model
+   :members: Spatial, fetch_zenodo_fingerprints
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: profsea.components.core.state
+   :members: ClimateState, SpatialState
+
+.. automodule:: profsea.components.core.time_projection
+   :members: time_projection
+
+Global Components
+-----------------
+
+.. automodule:: profsea.components.global_.antarctica
+   :members: AntarcticaISMIP6, AntarcticaDynAR5, AntarcticaSMBAR5
+
+.. automodule:: profsea.components.global_.greenland
+   :members: GreenlandAR6, GreenlandSMBAR5, GreenlandDynAR5, load_greenland_calibration
+
+.. automodule:: profsea.components.global_.glacier
+   :members: Glacier
+
+.. automodule:: profsea.components.global_.expansion
+   :members: ThermalExpansion
+
+.. automodule:: profsea.components.global_.landwater
+   :members: LandwaterAR6, LandwaterAR5, load_landwater_projection
+
+Spatial Components
+------------------
+
+.. automodule:: profsea.components.spatial.fingerprint
+   :members: Fingerprint
+
+.. automodule:: profsea.components.spatial.sterodynamic
+   :members: SterodynamicCMIP6, SterodynamicCMIP5
+
+.. automodule:: profsea.components.spatial.gia
+   :members: GIA

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,7 @@ release = '1.0.0'
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "nbsphinx",
 ]
 
 napoleon_google_docstring = False
@@ -55,6 +56,10 @@ autodoc_mock_imports = [
 
 templates_path = ['_templates']
 exclude_patterns = []
+
+nbsphinx_prolog = ""
+# Allow nbsphinx to find notebooks outside the docs/source directory
+nbsphinx_allow_errors = False
 
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,72 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'profsea-climate'
+copyright = '2026, MetOffice'
+author = 'isabellaascione'
+release = '1.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+]
+
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = True
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+
+autodoc_mock_imports = [
+    "cartopy",
+    "dask",
+    "fair",
+    "matplotlib",
+    "numcodecs",
+    "numpy",
+    "pandas",
+    "profsea.emulator",
+    "profsea.plotting_libraries",
+    "requests",
+    "rich",
+    "rich_argparse",
+    "scipy",
+    "xarray",
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'pydata_sphinx_theme'
+html_theme_options = {
+    'show_nav_level': 2,
+    'secondary_sidebar_items': [],
+}
+html_sidebars = {
+    "**": ["search-field", "sidebar-nav-bs", "page-toc"],
+}
+html_static_path = ['_static']

--- a/docs/source/development_guidelines.rst
+++ b/docs/source/development_guidelines.rst
@@ -9,7 +9,7 @@ This is the Development Guidelines page.
 
 Open an Issue
 -------------
-Before forking the repository, open an issue in the main repository to describe the changes you plan to make. This helps maintainers track contributions and provide feedback early.
+Before forking the repository, open an issue in the main repository to describe the changes you plan to make. This helps maintainers track contributions and provide feedback early. Check with the repository owners what is the name of the development branch you need to use. In this guide, the name used for the development branch is generically indicated as "development_branch_name"
 
 .. _fork-the-repository:
 
@@ -25,15 +25,17 @@ First, create a fork of the repository in your GitHub account:
 
 Clone Your Fork
 ---------------
-Clone your forked repository and switch to the `profsea-climate` branch:
+Clone your forked repository and switch to the `development_branch_name` branch:
 
 .. code-block:: bash
 
    git clone git@github.com:<your-username>/ProFSea-tool.git
    cd ProFSea-tool
-   git checkout profsea-climate
+   git checkout <development_branch_name>
 
 Replace ``<your-username>`` with your GitHub username.
+
+Replace ``<development_branch_name>`` with the development branch name provided by the repository owners
 
 .. _commit-changes-to-your-fork:
 
@@ -45,7 +47,7 @@ Once you are satisfied with your changes, commit and push them to your fork:
 
    git add .
    git commit -m "Adding feature: <brief description of changes>"
-   git push origin profsea-climate
+   git push origin development_branch_name
 
 Replace ``<brief description of changes>`` with a short summary of your updates.
 
@@ -57,7 +59,8 @@ To contribute your changes to the main repository:
 
 1. Go to your forked repository on GitHub.
 2. Click the **Pull Request** button.
-3. Select the ``profsea-climate`` branch of the main repository as the base branch.
-4. Select the ``profsea-climate`` branch of your fork as the compare branch.
+3. Select the ``development_branch_name`` branch of the main repository as the base branch.
+4. Select the ``development_branch_name`` branch of your fork as the compare branch.
 5. Add a title and description for your pull request.
 6. Click **Create Pull Request**.
+7. Assign reviewers to the pull request

--- a/docs/source/development_guidelines.rst
+++ b/docs/source/development_guidelines.rst
@@ -1,0 +1,63 @@
+.. _development_guidelines:
+
+Development Guidelines
+======================
+
+This is the Development Guidelines page.
+
+.. _open-an-issue:
+
+Open an Issue
+-------------
+Before forking the repository, open an issue in the main repository to describe the changes you plan to make. This helps maintainers track contributions and provide feedback early.
+
+.. _fork-the-repository:
+
+Fork the Repository
+-------------------
+First, create a fork of the repository in your GitHub account:
+
+1. Go to the repository page on GitHub.
+2. Click the **Fork** button in the top-right corner.
+3. Select your GitHub account as the destination for the fork.
+
+.. _clone-your-fork:
+
+Clone Your Fork
+---------------
+Clone your forked repository and switch to the `profsea-climate` branch:
+
+.. code-block:: bash
+
+   git clone git@github.com:<your-username>/ProFSea-tool.git
+   cd ProFSea-tool
+   git checkout profsea-climate
+
+Replace ``<your-username>`` with your GitHub username.
+
+.. _commit-changes-to-your-fork:
+
+Commit Changes to Your Fork
+---------------------------
+Once you are satisfied with your changes, commit and push them to your fork:
+
+.. code-block:: bash
+
+   git add .
+   git commit -m "Adding feature: <brief description of changes>"
+   git push origin profsea-climate
+
+Replace ``<brief description of changes>`` with a short summary of your updates.
+
+.. _create-a-pull-request:
+
+Create a Pull Request
+---------------------
+To contribute your changes to the main repository:
+
+1. Go to your forked repository on GitHub.
+2. Click the **Pull Request** button.
+3. Select the ``profsea-climate`` branch of the main repository as the base branch.
+4. Select the ``profsea-climate`` branch of your fork as the compare branch.
+5. Add a title and description for your pull request.
+6. Click **Create Pull Request**.

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -1,0 +1,82 @@
+How to update the documentation
+========================================
+
+This is the page describing how to update the documentation.
+
+If you want to update the documentation, follow these steps to ensure that your changes are tested locally before contributing:
+
+1. Initial Steps
+-----------------------------------
+First of all you need to open an issue, fork and clone the repository. For detailed instructions, refer to the following sections in the :ref:`Development Guidelines <development_guidelines>` page:
+
+- :ref:`Open an Issue <open-an-issue>`
+- :ref:`Fork the Repository <fork-the-repository>`
+- :ref:`Clone Your Fork <clone-your-fork>`
+
+2. Set Up the Environment
+-------------------------
+Ensure you have the required dependencies installed to build the documentation.
+
+2.1 Create a Conda Environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you are using Conda, create the environment from the ``environment.yml`` file:
+
+.. code-block:: bash
+
+   conda env create -f environment.yml
+   conda activate profsea-climate-docs
+
+2.2 Install Dependencies with Pip (Optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you are not using Conda, install the dependencies with ``pip``:
+
+.. code-block:: bash
+
+   pip install sphinx pydata-sphinx-theme
+
+3. Make Changes to the Documentation
+-------------------------------------
+Edit or add ``.rst`` files in the ``docs/source`` directory. For example:
+
+- Update ``index.rst`` to include new pages.
+- Modify existing ``.rst`` files to update content.
+- Add new ``.rst`` files for additional sections.
+
+4. Build the Documentation Locally
+-----------------------------------
+Before committing your changes, build the documentation locally to ensure there are no errors:
+
+.. code-block:: bash
+
+   cd docs
+   make html
+
+This will generate the HTML files in the ``docs/build/html`` directory. Open the ``index.html`` file in your browser to preview the changes:
+
+.. code-block:: bash
+
+   xdg-open build/html/index.html
+
+5. Test the Documentation
+--------------------------
+- Verify that all links work correctly.
+- Ensure the side menu and table of contents are updated.
+- Check for any warnings or errors in the terminal output during the build process.
+
+6. Commit Changes and Create a Pull Request
+---------------------------------------------
+Once you are satisfied with your changes, commit and push them to your fork. For detailed instructions,
+refer to the following sections in the :ref:`Development Guidelines <development_guidelines>` page:
+- :ref:`Commit Changes to Your Fork <commit-changes-to-your-fork>`
+- :ref:`Create a Pull Request <create-a-pull-request>`
+
+7. Verify Deployment
+---------------------
+After your pull request is merged, the GitHub Actions workflow will automatically build and deploy the updated documentation. Verify that the changes are live on GitHub Pages:
+
+1. Go to the **Actions** tab in the main repository.
+2. Check the logs for the ``deploy-docs.yml`` workflow to ensure it completed successfully.
+3. Visit the GitHub Pages URL to confirm the updates.
+
+Notes
+-----

--- a/docs/source/documentation.rst
+++ b/docs/source/documentation.rst
@@ -1,7 +1,7 @@
 How to update the documentation
 ========================================
 
-This is the page describing how to update the documentation.
+This is the page describing how to update the sphinx documentation.
 
 If you want to update the documentation, follow these steps to ensure that your changes are tested locally before contributing:
 
@@ -19,12 +19,12 @@ Ensure you have the required dependencies installed to build the documentation.
 
 2.1 Create a Conda Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you are using Conda, create the environment from the ``environment.yml`` file:
+If you are using Conda, create the environment from the ``docs-environment.yml`` file:
 
 .. code-block:: bash
 
-   conda env create -f environment.yml
-   conda activate profsea-climate-docs
+   conda env create -f docs-environment.yml
+   conda activate profsea-sphinx-docs
 
 2.2 Install Dependencies with Pip (Optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -72,7 +72,7 @@ refer to the following sections in the :ref:`Development Guidelines <development
 
 7. Verify Deployment
 ---------------------
-After your pull request is merged, the GitHub Actions workflow will automatically build and deploy the updated documentation. Verify that the changes are live on GitHub Pages:
+After your pull request is reviewed and merged, the GitHub Actions workflow will automatically build and deploy the updated documentation. Verify that the changes are live on GitHub Pages:
 
 1. Go to the **Actions** tab in the main repository.
 2. Check the logs for the ``deploy-docs.yml`` workflow to ensure it completed successfully.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,48 @@
+.. profsea-climate documentation master file, created by
+   sphinx-quickstart on Wed Apr  8 11:10:23 2026.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+profsea-climate documentation
+=============================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   user_guide
+   development_guidelines
+   documentation
+   api_reference
+   references
+
+User Guide
+----------
+
+See :doc:`user_guide`.
+
+Development Guidelines
+----------------------
+
+See :doc:`development_guidelines`.
+
+Documentation Guide
+-------------------
+
+See :doc:`documentation`.
+
+API Reference
+-------------
+
+See :doc:`api_reference`.
+
+References
+----------
+
+See :doc:`references`.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,9 @@
-.. profsea-climate documentation master file, created by
+.. profsea documentation master file, created by
    sphinx-quickstart on Wed Apr  8 11:10:23 2026.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-profsea-climate documentation
+profsea documentation
 =============================
 
 Add your content using ``reStructuredText`` syntax. See the
@@ -25,6 +25,7 @@ User Guide
 ----------
 
 See :doc:`user_guide`.
+The worked tutorial notebook is listed on that page.
 
 Development Guidelines
 ----------------------

--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -1,0 +1,4 @@
+References
+==========
+
+This is the References page.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -2,3 +2,13 @@ User Guide
 ==========
 
 This is the User Guide page
+
+Tutorial Notebook
+-----------------
+
+The worked tutorial notebook is available below:
+
+.. toctree::
+	:maxdepth: 1
+
+	worked_example

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,4 @@
+User Guide
+==========
+
+This is the User Guide page

--- a/docs/source/worked_example.ipynb
+++ b/docs/source/worked_example.ipynb
@@ -1,0 +1,1 @@
+../../profsea/tutorial_notebooks/worked_example.ipynb

--- a/profsea/components/core/global_model.py
+++ b/profsea/components/core/global_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import concurrent.futures
 from pathlib import Path
 import os

--- a/profsea/components/core/spatial_model.py
+++ b/profsea/components/core/spatial_model.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import Dict

--- a/profsea/components/core/state.py
+++ b/profsea/components/core/state.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 import numpy as np
 

--- a/profsea/components/global_/antarctica.py
+++ b/profsea/components/global_/antarctica.py
@@ -238,8 +238,8 @@ class AntarcticaDynAR5(Component):
         """Project Antarctic rapid ice-sheet dynamics contribution to GMSLR.
 
         Parameters
-            ----------
-            fraction: np.ndarray
+        ----------
+        fraction: np.ndarray
             Random numbers for the dynamic contribution.
 
         Returns

--- a/profsea/components/global_/expansion.py
+++ b/profsea/components/global_/expansion.py
@@ -7,8 +7,8 @@ from profsea.utils import check_shapes
 
 class ThermalExpansion(Component):
     """
-    Parameters & Attributes
-    ----------
+    Parameters and Attributes
+    -------------------------
     OHC_change: np.ndarray
         Array of ocean heat content change values.
     exp_efficiency: float

--- a/profsea/components/spatial/sterodynamic.py
+++ b/profsea/components/spatial/sterodynamic.py
@@ -14,8 +14,8 @@ PATTERNS_DIR = PROFSEA_DIR / "profsea-assets" / "cmip6-patterns"
 
 class SterodynamicCMIP6(SpatialComponent):
     """
-    Parameters & Attributes
-    ----------
+    Parameters and Attributes
+    -------------------------
     global_projection: np.ndarray
         Array of global sea level rise projections to use as input for sterodynamic projection.
     """


### PR DESCRIPTION
related to #65 

replaces #47 because target has changed to profsea-v3.

This PR includes:

- Enabled documentation build and deployment to GitHub Pages using Sphinx.
- Added and organized documentation pages for the User Guide, Development Guidelines, tutorial notebooks, and guidance for updating the Sphinx docs.
- Added API reference generation from docstrings.
- Enabled rendering of existing Jupyter notebooks in the Sphinx documentation.

the output docs can be previewed at the following link :

https://isabellaascione.github.io/ProFSea-tool/

The PR needs to be reviewed


